### PR TITLE
feat: support `hyprcursor`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Build
-        run: nix build . -Lv
+        run: nix build . -L
       - name: Add zips to release
         run: gh release upload ${{ needs.release-please.outputs.tag_name }} result/*.zip
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 pngs/
 releases/
 result
+hl/

--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Build script:
  Keefer Rourke <keefer.rourke@gmail.com>
  Moded by Efus10n & jnzhng from https://github.com/keeferrourke/capitaine-cursors
  Goudham Suresh <https://github.com/sgoudham> - script performance improvements
+ Jeffrey Geer <https://github.com/trowgundam> - hyprcursor support

--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ pkgs.catppuccin-cursors.mochaMauve
 - [xcursorgen](https://wiki.archlinux.org/title/Xcursorgen) to generate the
   cursors.
 - [inkscape](https://wiki.inkscape.org/wiki/Inkscape) to convert SVGs to PNGs.
+- **(Optional)** [hyprcursor](https://github.com/hyprwm/hyprcursor) to include
+  hyprcursor variants.
 - **(Optional)** [just](https://github.com/casey/just) to easily run development
   commands.
-- **(Optional)** [hyprcursor](https://github.com/hyprwm/hyprcursor) to build
-  hyprcursor theme
 
 ### Steps
 
@@ -112,17 +112,15 @@ pkgs.catppuccin-cursors.mochaMauve
    ```
 
 1. Run the following command(s) if you have just installed, if not then look
-   inside the [justfile](./justfile) to understand what commands are being run.
-   All of the following support the `-h` flag to enable building of then
-   hyprcursor theme.
+   inside the [justfile](./justfile) to understand what commands are being run. 
 
    ```bash
    just all # Build all flavor-accent variants.
-   just all -h # Build all flavor-accent variants with hyprcursor support
-   just flavor mocha # To build all variants under one single flavor.
-   just flavor mocha -h # To build all variants under one single flavor with hyprcursor support
-   just accents mocha blue # To build only the blue variant under mocha.
-   just accents mocha 'blue mauve peach' # To build only the blue, mauve, and peach variants under mocha.
+   just all_with_hyprcursor # Build all flavor-accent variants with hyprcursor support
+   just build mocha # To build all variants under one single flavor.
+   just build_with_hyprcursor mocha # To build all variants under one single flavor with hyprcursor support
+   just build mocha blue # To build only the blue variant under mocha.
+   just build mocha 'blue mauve peach' # To build only the blue, mauve, and peach variants under mocha.
    ```
 
 1. Extract built cursors in `./dist` to `$HOME/.icons` or `/usr/share/icons`.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ pkgs.catppuccin-cursors.mochaMauve
 - [inkscape](https://wiki.inkscape.org/wiki/Inkscape) to convert SVGs to PNGs.
 - **(Optional)** [just](https://github.com/casey/just) to easily run development
   commands.
+- **(Optional)** [hyprcursor](https://github.com/hyprwm/hyprcursor) to build
+  hyprcursor theme
 
 ### Steps
 
@@ -111,10 +113,14 @@ pkgs.catppuccin-cursors.mochaMauve
 
 1. Run the following command(s) if you have just installed, if not then look
    inside the [justfile](./justfile) to understand what commands are being run.
+   All of the following support the `-h` flag to enable building of then
+   hyprcursor theme.
 
    ```bash
    just all # Build all flavor-accent variants.
+   just all -h # Build all flavor-accent variants with hyprcursor support
    just flavor mocha # To build all variants under one single flavor.
+   just flavor mocha -h # To build all variants under one single flavor with hyprcursor support
    just accents mocha blue # To build only the blue variant under mocha.
    just accents mocha 'blue mauve peach' # To build only the blue, mauve, and peach variants under mocha.
    ```

--- a/build
+++ b/build
@@ -63,33 +63,29 @@ create_hyprcursors() {
   local out_dir="$2"
   local theme_name="$3"
   local hypr_dir="$out_dir/hyprcursors"
-  local filename dir cursor_dir striped base_name symlink target cursor_dir theme_comment
+  local filename dir cursor_dir base_name symlink target theme_comment
 
-  [ -d "$src_dir" ] || return 1
   [ -d "$out_dir" ] || mkdir -p "$out_dir"
   [ -d "$hypr_dir" ] || mkdir -p "$hypr_dir"
 
   for file in "$src_dir"/*.svg; do
     filename=$(basename -- "$file")
 
+    # hyprcursor doesn't care about sizes of svgs, can skip the '_24.svg' variant with no impact
     if [[ "$filename" == *_24.svg ]]; then
       continue
     fi
+
+    # we want to put all of the `progress_01, progress_02, etc` into the same directory of `progress`
     if [[ "$filename" == *-[0-9][0-9].svg ]]; then
       dir="${filename%-[0-9][0-9].svg}"
-      cursor_dir="$hypr_dir/$dir"
-      striped="${filename#"$dir"}"
-
-      [ -d "$cursor_dir" ] || mkdir -p "$cursor_dir"
-      cp -- "$file" "$cursor_dir"
     else
       dir="${filename%.svg}"
-      cursor_dir="$hypr_dir/$dir"
-
-      [ -d "$cursor_dir" ] || mkdir -p "$cursor_dir"
-
-      cp -- "$file" "$cursor_dir"
     fi
+
+    cursor_dir="$hypr_dir/$dir"
+    [ -d "$cursor_dir" ] || mkdir -p "$cursor_dir"
+    cp -- "$file" "$cursor_dir"
   done
 
   for config in "$CONFIG_DIR"/*.hl; do
@@ -112,22 +108,21 @@ create_hyprcursors() {
   cat >"$out_dir"/manifest.hl <<-EOM
 		name = ${theme_name%-cursors}
 		description = ${theme_comment#Comment=}
-		version = $(git show -s --format=%cd --date=format:%Y%m%d HEAD)
+    version = "v0.2.1" # x-release-please-version
 		cursors_directory = hyprcursors
 	EOM
 }
 
 compile_hyprcursors() {
-  local src_dir="$1"
+  local hl_dir="$1"
   local out_dir="$2"
   local theme_name="$(basename "$1")"
   local compile_dir="$1/../theme_${theme_name%-cursors}"
-  local filename dir cursor_dir striped base_name symlink target cursor_dir
 
-  [ -d "$src_dir" ] || return 1
+  [ -d "$hl_dir" ] || return 1
   [ -d "$out_dir" ] || mkdir -p "$out_dir"
 
-  hyprcursor-util -c "$src_dir" >/dev/null
+  hyprcursor-util -c "$hl_dir" >/dev/null
   cp -a "$compile_dir/." "$out_dir/"
 }
 
@@ -144,20 +139,15 @@ ALIASES="$SRC_DIR/cursorList"
 
 ACCENTS="blue dark flamingo green lavender light maroon mauve peach pink red rosewater sapphire sky teal yellow"
 INKSCAPE_COMMANDS=""
-
 HYPRCURSOR=0
 
-while getopts "f:a:vh" option; do
+while getopts "f:a:h" option; do
   case $option in
   f)
     FLAVOR="$OPTARG"
     ;;
   a)
     ACCENTS="$OPTARG"
-    ;;
-  v)
-    DEBUG=1
-    echo "[DEBUG] - Debug logging enabled"
     ;;
   h)
     HYPRCURSOR=1
@@ -170,6 +160,11 @@ while getopts "f:a:vh" option; do
 done
 echo "[INFO] - Flavor: '$FLAVOR'"
 echo "[INFO] - Accent(s): '$ACCENTS'"
+if [ $HYPRCURSOR -eq 1 ]; then
+  echo "[INFO] - Building with hyprcursor: TRUE"
+else
+  echo "[INFO] - Building with hyprcursor: FALSE"
+fi
 
 echo "[INFO] - Generating inkscape commands..."
 for accent in $ACCENTS; do
@@ -183,7 +178,7 @@ done
 echo "[INFO] - Generating inkscape commands complete"
 
 echo "[INFO] - Converting SVGs to PNGs..."
-inkscape --shell <<< ${INKSCAPE_COMMANDS} &> /dev/null
+inkscape --shell <<<${INKSCAPE_COMMANDS} &>/dev/null
 echo "[INFO] - Converting SVGs to PNGs complete"
 
 echo "[INFO] - Converting to x11cursor & creating aliases..."

--- a/build
+++ b/build
@@ -136,7 +136,6 @@ SRC_DIR="$SCRIPT_DIR/src"
 OUT_DIR="$SCRIPT_DIR/dist"
 PNG_DIR="$SCRIPT_DIR/pngs"
 HL_DIR="$SCRIPT_DIR/hl"
-BUILD_DIR="$SCRIPT_DIR/build"
 CONFIG_DIR="$SRC_DIR/config"
 
 AUTHORS="$SCRIPT_DIR/AUTHORS"
@@ -176,7 +175,6 @@ echo "[INFO] - Generating inkscape commands..."
 for accent in $ACCENTS; do
   theme_name="catppuccin-$FLAVOR-$accent-cursors"
   theme_src_dir="$SRC_DIR/$theme_name"
-  theme_build_dir="$BUILD_DIR/$theme_name"
   theme_out_dir="$OUT_DIR/$theme_name"
   theme_png_dir="$PNG_DIR/$theme_name"
 
@@ -192,7 +190,6 @@ echo "[INFO] - Converting to x11cursor & creating aliases..."
 for accent in $ACCENTS; do
   theme_name="catppuccin-$FLAVOR-$accent-cursors"
   theme_src_dir="$SRC_DIR/$theme_name"
-  theme_build_dir="$BUILD_DIR/$theme_name"
   theme_out_dir="$OUT_DIR/$theme_name"
   theme_png_dir="$PNG_DIR/$theme_name"
 
@@ -210,11 +207,11 @@ if [[ $HYPRCURSOR == 1 ]]; then
   for accent in $ACCENTS; do
     theme_name="catppuccin-$FLAVOR-$accent-cursors"
     theme_src_dir="$SRC_DIR/$theme_name"
-    theme_build_dir="$HL_DIR/$theme_name"
+    theme_hl_dir="$HL_DIR/$theme_name"
     theme_out_dir="$OUT_DIR/$theme_name"
 
-    create_hyprcursors "$theme_src_dir" "$theme_build_dir" "$theme_name"
-    compile_hyprcursors "$theme_build_dir" "$theme_out_dir"
+    create_hyprcursors "$theme_src_dir" "$theme_hl_dir" "$theme_name"
+    compile_hyprcursors "$theme_hl_dir" "$theme_out_dir"
   done
   echo "[INFO] - Generating hyprcursor theme complete"
 fi

--- a/build
+++ b/build
@@ -106,11 +106,11 @@ create_hyprcursors() {
 
   theme_comment="$(grep Comment "$src_dir"/index.theme)"
   cat >"$out_dir"/manifest.hl <<-EOM
-		name = ${theme_name%-cursors}
-		description = ${theme_comment#Comment=}
+    name = ${theme_name%-cursors}
+    description = ${theme_comment#Comment=}
     version = "v0.2.1" # x-release-please-version
-		cursors_directory = hyprcursors
-	EOM
+    cursors_directory = hyprcursors
+  EOM
 }
 
 compile_hyprcursors() {

--- a/build
+++ b/build
@@ -58,10 +58,84 @@ create_aliases() {
   done <"$ALIASES"
 }
 
+create_hyprcursors() {
+  local src_dir="$1"
+  local out_dir="$2"
+  local theme_name="$3"
+  local hypr_dir="$out_dir/hyprcursors"
+  local filename dir cursor_dir striped base_name symlink target cursor_dir theme_comment
+
+  [ -d "$src_dir" ] || return 1
+  [ -d "$out_dir" ] || mkdir -p "$out_dir"
+  [ -d "$hypr_dir" ] || mkdir -p "$hypr_dir"
+
+  for file in "$src_dir"/*.svg; do
+    filename=$(basename -- "$file")
+
+    if [[ "$filename" == *_24.svg ]]; then
+      continue
+    fi
+    if [[ "$filename" == *-[0-9][0-9].svg ]]; then
+      dir="${filename%-[0-9][0-9].svg}"
+      cursor_dir="$hypr_dir/$dir"
+      striped="${filename#"$dir"}"
+
+      [ -d "$cursor_dir" ] || mkdir -p "$cursor_dir"
+      cp -- "$file" "$cursor_dir"
+    else
+      dir="${filename%.svg}"
+      cursor_dir="$hypr_dir/$dir"
+
+      [ -d "$cursor_dir" ] || mkdir -p "$cursor_dir"
+
+      cp -- "$file" "$cursor_dir"
+    fi
+  done
+
+  for config in "$CONFIG_DIR"/*.hl; do
+    [ -f "$config" ] || continue
+
+    base_name="$(basename "$config" .hl)"
+    cursor_dir="$hypr_dir/$base_name"
+    [ -d "$cursor_dir" ] || continue
+    cp "$config" "$cursor_dir/meta.hl"
+  done
+
+  while read -r symlink target; do
+    cursor_dir="$out_dir/$target"
+    if [ -f "$cursor_dir"/meta.hl ]; then
+      echo "define_override = $symlink" >>"$cursor_dir"/meta.hl
+    fi
+  done <"$ALIASES"
+
+  theme_comment="$(grep Comment "$src_dir"/index.theme)"
+  cat >"$out_dir"/manifest.hl <<-EOM
+		name = ${theme_name%-cursors}
+		description = ${theme_comment#Comment=}
+		version = $(git show -s --format=%cd --date=format:%Y%m%d HEAD)
+		cursors_directory = hyprcursors
+	EOM
+}
+
+compile_hyprcursors() {
+  local src_dir="$1"
+  local out_dir="$2"
+  local theme_name="$(basename "$1")"
+  local compile_dir="$1/../theme_${theme_name%-cursors}"
+  local filename dir cursor_dir striped base_name symlink target cursor_dir
+
+  [ -d "$src_dir" ] || return 1
+  [ -d "$out_dir" ] || mkdir -p "$out_dir"
+
+  hyprcursor-util -c "$src_dir" >/dev/null
+  cp -a "$compile_dir/." "$out_dir/"
+}
+
 SCRIPT_DIR="$(dirname "$0")"
 SRC_DIR="$SCRIPT_DIR/src"
 OUT_DIR="$SCRIPT_DIR/dist"
 PNG_DIR="$SCRIPT_DIR/pngs"
+HL_DIR="$SCRIPT_DIR/hl"
 BUILD_DIR="$SCRIPT_DIR/build"
 CONFIG_DIR="$SRC_DIR/config"
 
@@ -72,7 +146,9 @@ ALIASES="$SRC_DIR/cursorList"
 ACCENTS="blue dark flamingo green lavender light maroon mauve peach pink red rosewater sapphire sky teal yellow"
 INKSCAPE_COMMANDS=""
 
-while getopts "f:a:v" option; do
+HYPRCURSOR=0
+
+while getopts "f:a:vh" option; do
   case $option in
   f)
     FLAVOR="$OPTARG"
@@ -83,6 +159,9 @@ while getopts "f:a:v" option; do
   v)
     DEBUG=1
     echo "[DEBUG] - Debug logging enabled"
+    ;;
+  h)
+    HYPRCURSOR=1
     ;;
   \?)
     echo "Invalid option: -$OPTARG"
@@ -125,3 +204,17 @@ for accent in $ACCENTS; do
   cp -f "$LICENSE" "$theme_out_dir"
 done
 echo "[INFO] - Converting to x11cursor & creating aliases complete"
+
+if [[ $HYPRCURSOR == 1 ]]; then
+  echo "[INFO] - Generating hyprcursor theme..."
+  for accent in $ACCENTS; do
+    theme_name="catppuccin-$FLAVOR-$accent-cursors"
+    theme_src_dir="$SRC_DIR/$theme_name"
+    theme_build_dir="$HL_DIR/$theme_name"
+    theme_out_dir="$OUT_DIR/$theme_name"
+
+    create_hyprcursors "$theme_src_dir" "$theme_build_dir" "$theme_name"
+    compile_hyprcursors "$theme_build_dir" "$theme_out_dir"
+  done
+  echo "[INFO] - Generating hyprcursor theme complete"
+fi

--- a/build
+++ b/build
@@ -106,11 +106,11 @@ create_hyprcursors() {
 
   theme_comment="$(grep Comment "$src_dir"/index.theme)"
   cat >"$out_dir"/manifest.hl <<-EOM
-    name = ${theme_name%-cursors}
-    description = ${theme_comment#Comment=}
-    version = "v0.2.1" # x-release-please-version
-    cursors_directory = hyprcursors
-  EOM
+name = ${theme_name%-cursors}
+description = ${theme_comment#Comment=}
+version = "v0.2.1" # x-release-please-version
+cursors_directory = hyprcursors
+EOM
 }
 
 compile_hyprcursors() {

--- a/default.nix
+++ b/default.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation {
     runHook preBuild
 
     patchShebangs .
-    just all
+    just all_with_hyprcursor
     just zip
 
     runHook postBuild

--- a/justfile
+++ b/justfile
@@ -7,17 +7,25 @@ accents := "blue dark flamingo green lavender light maroon mauve peach pink red 
 clean:
   rm -rf pngs/ hl/ dist/ releases/
 
+# Remove all hyprcursor related files
+clean_hl:
+  rm -rf hl/
+
 # Zip all directories inside of "./dist"
 zip:
   ./create_zips
 
-# Generate a single flavor with specific accents. E.g. "build mocha 'blue'"
-accents f a *flags:
-  ./build -f {{f}} -a '{{a}}' '{{flags}}'
+# Generate a single flavor with accents, defaults to all accents
+build f a=accents:
+  ./build -f {{f}} -a '{{a}}'
 
-# Generate a single flavor with all accents
-flavor f *flags:
-  ./build -f {{f}} -a "{{accents}}" '{{flags}}'
+# Generate a single flavor with accents with hyprcursor support, defaults to all accents
+build_with_hyprcursor f a=accents: clean_hl
+  ./build -f {{f}} -a '{{a}}' -h
 
 # Generate all flavors with their accents
-all *flags: clean (flavor "latte" flags) (flavor "frappe" flags) (flavor "macchiato" flags) (flavor "mocha" flags)
+all: clean (build "latte") (build "frappe") (build "macchiato") (build "mocha")
+
+# Generate all flavors with their accents with hyprcursor support
+all_with_hyprcursor: clean (build_with_hyprcursor "latte") (build_with_hyprcursor "frappe") (build_with_hyprcursor "macchiato") (build_with_hyprcursor "mocha")
+

--- a/justfile
+++ b/justfile
@@ -3,21 +3,21 @@ _default:
 
 accents := "blue dark flamingo green lavender light maroon mauve peach pink red rosewater sapphire sky teal yellow"
 
-# Remove all files in the ".pngs/", "./dist" and "./releases" directories
+# Remove all files in the ".pngs/", ".hl/", "./dist" and "./releases" directories
 clean:
-  rm -rf pngs/ dist/ releases/
+  rm -rf pngs/ hl/ dist/ releases/
 
 # Zip all directories inside of "./dist"
 zip:
   ./create_zips
 
 # Generate a single flavor with specific accents. E.g. "build mocha 'blue'"
-accents f a:
-  ./build -f {{f}} -a '{{a}}'
+accents f a *flags:
+  ./build -f {{f}} -a '{{a}}' '{{flags}}'
 
 # Generate a single flavor with all accents
-flavor f:
-  ./build -f {{f}} -a "{{accents}}"
+flavor f *flags:
+  ./build -f {{f}} -a "{{accents}}" '{{flags}}'
 
 # Generate all flavors with their accents
-all: clean (flavor "latte") (flavor "frappe") (flavor "macchiato") (flavor "mocha")
+all *flags: clean (flavor "latte" flags) (flavor "frappe" flags) (flavor "macchiato" flags) (flavor "mocha" flags)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,8 @@
       "release-type": "simple",
       "draft-pull-request": true,
       "extra-files": [
-        { "type": "generic", "path": "README.md" }
+        { "type": "generic", "path": "README.md" },
+        { "type": "generic", "path": "build" }
       ]
     }
   },

--- a/src/config/alias.hl
+++ b/src/config/alias.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.0625
+hotspot_y = 0.0625
+define_size = 64, alias.svg

--- a/src/config/all-scroll.hl
+++ b/src/config/all-scroll.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.46875
+define_size = 64, all-scroll.svg

--- a/src/config/bottom_left_corner.hl
+++ b/src/config/bottom_left_corner.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.1875
+hotspot_y = 0.78125
+define_size = 64, bottom_left_corner.svg

--- a/src/config/bottom_right_corner.hl
+++ b/src/config/bottom_right_corner.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.78125
+hotspot_y = 0.78125
+define_size = 64, bottom_right_corner.svg

--- a/src/config/bottom_side.hl
+++ b/src/config/bottom_side.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.65625
+define_size = 64, bottom_side.svg

--- a/src/config/cell.hl
+++ b/src/config/cell.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.46875
+define_size = 64, cell.svg

--- a/src/config/center_ptr.hl
+++ b/src/config/center_ptr.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.21875
+define_size = 64, center_ptr.svg

--- a/src/config/col-resize.hl
+++ b/src/config/col-resize.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.46875
+define_size = 64, col-resize.svg

--- a/src/config/color-picker.hl
+++ b/src/config/color-picker.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.1875
+hotspot_y = 0.78125
+define_size = 64, color-picker.svg

--- a/src/config/context-menu.hl
+++ b/src/config/context-menu.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.0625
+hotspot_y = 0.0625
+define_size = 64, context-menu.svg

--- a/src/config/copy.hl
+++ b/src/config/copy.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.0625
+hotspot_y = 0.0625
+define_size = 64, copy.svg

--- a/src/config/crosshair.hl
+++ b/src/config/crosshair.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.46875
+define_size = 64, crosshair.svg

--- a/src/config/default.hl
+++ b/src/config/default.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.0625
+hotspot_y = 0.0625
+define_size = 64, default.svg

--- a/src/config/dnd-move.hl
+++ b/src/config/dnd-move.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.46875
+define_size = 64, dnd-move.svg

--- a/src/config/dnd-no-drop.hl
+++ b/src/config/dnd-no-drop.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.46875
+define_size = 64, dnd-no-drop.svg

--- a/src/config/down-arrow.hl
+++ b/src/config/down-arrow.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.75
+define_size = 64, down-arrow.svg

--- a/src/config/draft.hl
+++ b/src/config/draft.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.1875
+hotspot_y = 0.46875
+define_size = 64, draft.svg

--- a/src/config/fleur.hl
+++ b/src/config/fleur.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.46875
+define_size = 64, fleur.svg

--- a/src/config/help.hl
+++ b/src/config/help.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.0625
+hotspot_y = 0.0625
+define_size = 64, help.svg

--- a/src/config/left-arrow.hl
+++ b/src/config/left-arrow.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.21875
+hotspot_y = 0.46875
+define_size = 64, left-arrow.svg

--- a/src/config/left_side.hl
+++ b/src/config/left_side.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.28125
+hotspot_y = 0.46875
+define_size = 64, left_side.svg

--- a/src/config/no-drop.hl
+++ b/src/config/no-drop.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.0625
+hotspot_y = 0.0625
+define_size = 64, no-drop.svg

--- a/src/config/not-allowed.hl
+++ b/src/config/not-allowed.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.46875
+define_size = 64, not-allowed.svg

--- a/src/config/openhand.hl
+++ b/src/config/openhand.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.46875
+define_size = 64, openhand.svg

--- a/src/config/pencil.hl
+++ b/src/config/pencil.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.1875
+hotspot_y = 0.78125
+define_size = 64, pencil.svg

--- a/src/config/pirate.hl
+++ b/src/config/pirate.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.3125
+define_size = 64, pirate.svg

--- a/src/config/pointer.hl
+++ b/src/config/pointer.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.40625
+hotspot_y = 0.1875
+define_size = 64, pointer.svg

--- a/src/config/progress.hl
+++ b/src/config/progress.hl
@@ -1,0 +1,15 @@
+resize_algorithm = bilinear
+hotspot_x = 0.0625
+hotspot_y = 0.0625
+define_size = 64, progress-01.svg, 30
+define_size = 64, progress-02.svg, 30
+define_size = 64, progress-03.svg, 30
+define_size = 64, progress-04.svg, 30
+define_size = 64, progress-05.svg, 30
+define_size = 64, progress-06.svg, 30
+define_size = 64, progress-07.svg, 30
+define_size = 64, progress-08.svg, 30
+define_size = 64, progress-09.svg, 30
+define_size = 64, progress-10.svg, 30
+define_size = 64, progress-11.svg, 30
+define_size = 64, progress-12.svg, 30

--- a/src/config/right-arrow.hl
+++ b/src/config/right-arrow.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.75
+hotspot_y = 0.46875
+define_size = 64, right-arrow.svg

--- a/src/config/right_ptr.hl
+++ b/src/config/right_ptr.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.875
+hotspot_y = 0.0625
+define_size = 64, right_ptr.svg

--- a/src/config/right_side.hl
+++ b/src/config/right_side.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.65625
+hotspot_y = 0.46875
+define_size = 64, right_side.svg

--- a/src/config/row-resize.hl
+++ b/src/config/row-resize.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.46875
+define_size = 64, row-resize.svg

--- a/src/config/size_bdiag.hl
+++ b/src/config/size_bdiag.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.46875
+define_size = 64, size_bdiag.svg

--- a/src/config/size_fdiag.hl
+++ b/src/config/size_fdiag.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.46875
+define_size = 64, size_fdiag.svg

--- a/src/config/size_hor.hl
+++ b/src/config/size_hor.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.46875
+define_size = 64, size_hor.svg

--- a/src/config/size_ver.hl
+++ b/src/config/size_ver.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.46875
+define_size = 64, size_ver.svg

--- a/src/config/text.hl
+++ b/src/config/text.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.46875
+define_size = 64, text.svg

--- a/src/config/top_left_corner.hl
+++ b/src/config/top_left_corner.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.1875
+hotspot_y = 0.1875
+define_size = 64, top_left_corner.svg

--- a/src/config/top_right_corner.hl
+++ b/src/config/top_right_corner.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.78125
+hotspot_y = 0.1875
+define_size = 64, top_right_corner.svg

--- a/src/config/top_side.hl
+++ b/src/config/top_side.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.28125
+define_size = 64, top_side.svg

--- a/src/config/up-arrow.hl
+++ b/src/config/up-arrow.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.21875
+define_size = 64, up-arrow.svg

--- a/src/config/vertical-text.hl
+++ b/src/config/vertical-text.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.46875
+define_size = 64, vertical-text.svg

--- a/src/config/wait.hl
+++ b/src/config/wait.hl
@@ -1,0 +1,15 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.46875
+define_size = 64, wait-01.svg, 30
+define_size = 64, wait-02.svg, 30
+define_size = 64, wait-03.svg, 30
+define_size = 64, wait-04.svg, 30
+define_size = 64, wait-05.svg, 30
+define_size = 64, wait-06.svg, 30
+define_size = 64, wait-07.svg, 30
+define_size = 64, wait-08.svg, 30
+define_size = 64, wait-09.svg, 30
+define_size = 64, wait-10.svg, 30
+define_size = 64, wait-11.svg, 30
+define_size = 64, wait-12.svg, 30

--- a/src/config/wayland-cursor.hl
+++ b/src/config/wayland-cursor.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.46875
+define_size = 64, wayland-cursor.svg

--- a/src/config/x-cursor.hl
+++ b/src/config/x-cursor.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.46875
+hotspot_y = 0.46875
+define_size = 64, x-cursor.svg

--- a/src/config/zoom-in.hl
+++ b/src/config/zoom-in.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.40625
+hotspot_y = 0.40625
+define_size = 64, zoom-in.svg

--- a/src/config/zoom-out.hl
+++ b/src/config/zoom-out.hl
@@ -1,0 +1,4 @@
+resize_algorithm = bilinear
+hotspot_x = 0.40625
+hotspot_y = 0.40625
+define_size = 64, zoom-out.svg


### PR DESCRIPTION
I've added support for [hyprcursor](https://github.com/hyprwm/hyprcursor).

This is a re-implementation of #18 based on the recent reworking of the repository. It was easier to just re-implement things than trying to rebase and fixing things due to the change from `make` to `just`.