### PR TITLE
feat: support Plasma's SVG cursors implementation

### DIFF
--- a/build
+++ b/build
@@ -48,6 +48,29 @@ convert_to_x11cursor() {
   done
 }
 
+write_scalable() {
+  local src_dir="$1"
+  local out_dir="$2"
+  local config base_name
+
+  [ -d "$src_dir" ] || return 1
+
+  if [ -d "$out_dir" ]; then
+    rm -rf "$out_dir"
+  fi
+
+  mkdir -p "$out_dir"
+
+  for config in "$CONFIG_DIR"/*.json; do
+    [ -f "$config" ] || continue
+    base_name="$(basename "$config" .json)"
+    cursor_out="$out_dir/$base_name"
+    mkdir "$cursor_out"
+    find "$src_dir" -type f \( -name "$base_name-??.svg" -o -name "$base_name.svg" \) ! -name "*_24.svg" -exec cp {} "$cursor_out" \;
+    cp "$config" "$cursor_out/metadata.json"
+  done
+}
+
 create_aliases() {
   local out_dir="$1"
   local symlink target
@@ -156,7 +179,9 @@ for accent in $ACCENTS; do
   theme_png_dir="$PNG_DIR/$theme_name"
 
   convert_to_x11cursor "$theme_png_dir" "$theme_out_dir/cursors"
+  write_scalable "$theme_src_dir" "$theme_out_dir/cursors_scalable"
   create_aliases "$theme_out_dir/cursors"
+  create_aliases "$theme_out_dir/cursors_scalable"
 
   cp -f "$theme_src_dir/index.theme" "$theme_out_dir"
   cp -f "$AUTHORS" "$theme_out_dir"

--- a/src/config/alias.json
+++ b/src/config/alias.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "alias.svg",
+    "hotspot_x": 2,
+    "hotspot_y": 1,
+    "nominal_size": 24
+  }
+]

--- a/src/config/all-scroll.json
+++ b/src/config/all-scroll.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "all-scroll.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/bottom_left_corner.json
+++ b/src/config/bottom_left_corner.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "bottom_left_corner.svg",
+    "hotspot_x": 4,
+    "hotspot_y": 18,
+    "nominal_size": 24
+  }
+]

--- a/src/config/bottom_right_corner.json
+++ b/src/config/bottom_right_corner.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "bottom_right_corner.svg",
+    "hotspot_x": 19,
+    "hotspot_y": 18,
+    "nominal_size": 24
+  }
+]

--- a/src/config/bottom_side.json
+++ b/src/config/bottom_side.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "bottom_side.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 16,
+    "nominal_size": 24
+  }
+]

--- a/src/config/cell.json
+++ b/src/config/cell.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "cell.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/center_ptr.json
+++ b/src/config/center_ptr.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "center_ptr.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 5,
+    "nominal_size": 24
+  }
+]

--- a/src/config/col-resize.json
+++ b/src/config/col-resize.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "col-resize.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/color-picker.json
+++ b/src/config/color-picker.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "color-picker.svg",
+    "hotspot_x": 4,
+    "hotspot_y": 18,
+    "nominal_size": 24
+  }
+]

--- a/src/config/context-menu.json
+++ b/src/config/context-menu.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "context-menu.svg",
+    "hotspot_x": 2,
+    "hotspot_y": 1,
+    "nominal_size": 24
+  }
+]

--- a/src/config/copy.json
+++ b/src/config/copy.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "copy.svg",
+    "hotspot_x": 2,
+    "hotspot_y": 1,
+    "nominal_size": 24
+  }
+]

--- a/src/config/crosshair.json
+++ b/src/config/crosshair.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "crosshair.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "default.svg",
+    "hotspot_x": 2,
+    "hotspot_y": 1,
+    "nominal_size": 24
+  }
+]

--- a/src/config/dnd-move.json
+++ b/src/config/dnd-move.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "dnd-move.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/dnd-no-drop.json
+++ b/src/config/dnd-no-drop.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "dnd-no-drop.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/down-arrow.json
+++ b/src/config/down-arrow.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "down-arrow.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 18,
+    "nominal_size": 24
+  }
+]

--- a/src/config/draft.json
+++ b/src/config/draft.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "draft.svg",
+    "hotspot_x": 4,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/fleur.json
+++ b/src/config/fleur.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "fleur.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/help.json
+++ b/src/config/help.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "help.svg",
+    "hotspot_x": 2,
+    "hotspot_y": 1,
+    "nominal_size": 24
+  }
+]

--- a/src/config/left-arrow.json
+++ b/src/config/left-arrow.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "left-arrow.svg",
+    "hotspot_x": 4,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/left_side.json
+++ b/src/config/left_side.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "left_side.svg",
+    "hotspot_x": 7,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/no-drop.json
+++ b/src/config/no-drop.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "no-drop.svg",
+    "hotspot_x": 2,
+    "hotspot_y": 1,
+    "nominal_size": 24
+  }
+]

--- a/src/config/not-allowed.json
+++ b/src/config/not-allowed.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "not-allowed.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/openhand.json
+++ b/src/config/openhand.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "openhand.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/pencil.json
+++ b/src/config/pencil.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "pencil.svg",
+    "hotspot_x": 5,
+    "hotspot_y": 18,
+    "nominal_size": 24
+  }
+]

--- a/src/config/pirate.json
+++ b/src/config/pirate.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "pirate.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 8,
+    "nominal_size": 24
+  }
+]

--- a/src/config/pointer.json
+++ b/src/config/pointer.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "pointer.svg",
+    "hotspot_x": 9,
+    "hotspot_y": 4,
+    "nominal_size": 24
+  }
+]

--- a/src/config/progress.json
+++ b/src/config/progress.json
@@ -1,0 +1,86 @@
+[
+  {
+    "filename": "progress-01.svg",
+    "delay": 30,
+    "hotspot_x": 2,
+    "hotspot_y": 1,
+    "nominal_size": 24
+  },
+  {
+    "filename": "progress-02.svg",
+    "delay": 30,
+    "hotspot_x": 2,
+    "hotspot_y": 1,
+    "nominal_size": 24
+  },
+  {
+    "filename": "progress-03.svg",
+    "delay": 30,
+    "hotspot_x": 2,
+    "hotspot_y": 1,
+    "nominal_size": 24
+  },
+  {
+    "filename": "progress-04.svg",
+    "delay": 30,
+    "hotspot_x": 2,
+    "hotspot_y": 1,
+    "nominal_size": 24
+  },
+  {
+    "filename": "progress-05.svg",
+    "delay": 30,
+    "hotspot_x": 2,
+    "hotspot_y": 1,
+    "nominal_size": 24
+  },
+  {
+    "filename": "progress-06.svg",
+    "delay": 30,
+    "hotspot_x": 2,
+    "hotspot_y": 1,
+    "nominal_size": 24
+  },
+  {
+    "filename": "progress-07.svg",
+    "delay": 30,
+    "hotspot_x": 2,
+    "hotspot_y": 1,
+    "nominal_size": 24
+  },
+  {
+    "filename": "progress-08.svg",
+    "delay": 30,
+    "hotspot_x": 2,
+    "hotspot_y": 1,
+    "nominal_size": 24
+  },
+  {
+    "filename": "progress-09.svg",
+    "delay": 30,
+    "hotspot_x": 2,
+    "hotspot_y": 1,
+    "nominal_size": 24
+  },
+  {
+    "filename": "progress-10.svg",
+    "delay": 30,
+    "hotspot_x": 2,
+    "hotspot_y": 1,
+    "nominal_size": 24
+  },
+  {
+    "filename": "progress-11.svg",
+    "delay": 30,
+    "hotspot_x": 2,
+    "hotspot_y": 1,
+    "nominal_size": 24
+  },
+  {
+    "filename": "progress-12.svg",
+    "delay": 30,
+    "hotspot_x": 2,
+    "hotspot_y": 1,
+    "nominal_size": 24
+  }
+]

--- a/src/config/right-arrow.json
+++ b/src/config/right-arrow.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "right-arrow.svg",
+    "hotspot_x": 19,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/right_ptr.json
+++ b/src/config/right_ptr.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "right_ptr.svg",
+    "hotspot_x": 21,
+    "hotspot_y": 1,
+    "nominal_size": 24
+  }
+]

--- a/src/config/right_side.json
+++ b/src/config/right_side.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "right_side.svg",
+    "hotspot_x": 16,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/row-resize.json
+++ b/src/config/row-resize.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "row-resize.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/size_bdiag.json
+++ b/src/config/size_bdiag.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "size_bdiag.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/size_fdiag.json
+++ b/src/config/size_fdiag.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "size_fdiag.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/size_hor.json
+++ b/src/config/size_hor.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "size_hor.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/size_ver.json
+++ b/src/config/size_ver.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "size_ver.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/text.json
+++ b/src/config/text.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "text.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/top_left_corner.json
+++ b/src/config/top_left_corner.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "top_left_corner.svg",
+    "hotspot_x": 4,
+    "hotspot_y": 4,
+    "nominal_size": 24
+  }
+]

--- a/src/config/top_right_corner.json
+++ b/src/config/top_right_corner.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "top_right_corner.svg",
+    "hotspot_x": 19,
+    "hotspot_y": 4,
+    "nominal_size": 24
+  }
+]

--- a/src/config/top_side.json
+++ b/src/config/top_side.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "top_side.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 7,
+    "nominal_size": 24
+  }
+]

--- a/src/config/up-arrow.json
+++ b/src/config/up-arrow.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "up-arrow.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 4,
+    "nominal_size": 24
+  }
+]

--- a/src/config/vertical-text.json
+++ b/src/config/vertical-text.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "vertical-text.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/wait.json
+++ b/src/config/wait.json
@@ -1,0 +1,86 @@
+[
+  {
+    "filename": "wait-01.svg",
+    "delay": 30,
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  },
+  {
+    "filename": "wait-02.svg",
+    "delay": 30,
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  },
+  {
+    "filename": "wait-03.svg",
+    "delay": 30,
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  },
+  {
+    "filename": "wait-04.svg",
+    "delay": 30,
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  },
+  {
+    "filename": "wait-05.svg",
+    "delay": 30,
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  },
+  {
+    "filename": "wait-06.svg",
+    "delay": 30,
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  },
+  {
+    "filename": "wait-07.svg",
+    "delay": 30,
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  },
+  {
+    "filename": "wait-08.svg",
+    "delay": 30,
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  },
+  {
+    "filename": "wait-09.svg",
+    "delay": 30,
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  },
+  {
+    "filename": "wait-10.svg",
+    "delay": 30,
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  },
+  {
+    "filename": "wait-11.svg",
+    "delay": 30,
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  },
+  {
+    "filename": "wait-12.svg",
+    "delay": 30,
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/wayland-cursor.json
+++ b/src/config/wayland-cursor.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "wayland-cursor.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/x-cursor.json
+++ b/src/config/x-cursor.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "x-cursor.svg",
+    "hotspot_x": 11,
+    "hotspot_y": 11,
+    "nominal_size": 24
+  }
+]

--- a/src/config/zoom-in.json
+++ b/src/config/zoom-in.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "zoom-in.svg",
+    "hotspot_x": 10,
+    "hotspot_y": 9,
+    "nominal_size": 24
+  }
+]

--- a/src/config/zoom-out.json
+++ b/src/config/zoom-out.json
@@ -1,0 +1,8 @@
+[
+  {
+    "filename": "zoom-out.svg",
+    "hotspot_x": 10,
+    "hotspot_y": 9,
+    "nominal_size": 24
+  }
+]


### PR DESCRIPTION
With the release of Plasma 6.2 comes support for SVG Cursors, so I figured I'd go ahead an implement them since I'm now using Plasma. Luckily this is a much simpler implementation than Hyprcursor was It doesn't require a special utility or anything, so I didn't put it behind a flag. If you want that changed, I should be able to add that fairly easily.  Here is a screenshot of the cursor. It's a bit blurry, but that is because I had to screen record doing the mouse shake and then screen shot that, so the slight blurriness is just from my poor quality screen recording. It still looks miles better than the non-SVG version.
![Screenshot_20241012_175430](https://github.com/user-attachments/assets/099aeb3f-ff6a-4e90-b218-b06a29e86859)

Edit: Here is the blog post that I based this implementation on: https://blog.vladzahorodnii.com/2024/10/06/svg-cursors-everything-that-you-need-to-know-about-them/